### PR TITLE
Add pdftools to imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Imports:
     magick,
     methods,
     rvcheck (>= 0.1.0),
+    pdftools,
     scales,
     tibble,
     tools


### PR DESCRIPTION
Without pdftools installed, library(ggimage) fails; this corrects that.