### PR TITLE
alpha value to change the transparency of images,

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,5 +39,5 @@ License: Artistic-2.0
 URL: https://github.com/YuLab-SMU/ggimage
 BugReports: https://github.com/YuLab-SMU/ggimage/issues
 Encoding: UTF-8
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)

--- a/R/geom_image.R
+++ b/R/geom_image.R
@@ -273,12 +273,15 @@ prepare_image <- function(img, colour, opacity, angle, image_fun, use_cache = TR
       if (!is.null(angle) && !is.na(angle) && angle != 0) {
         transformed <- magick::image_rotate(transformed, angle)
       }
-
       # color/opacity（execute for the color setting）
       if (!is.null(colour) && !is.na(colour)) {
         # ?? image_colorize(opacity=?, color=?)
         # use the same API；opacity set as 0-100 percentage
-        transformed <- magick::image_colorize(transformed, opacity = opacity, color = colour)
+        transformed <- magick::image_colorize(transformed, opacity = 100, color = colour)
+        if (!is.null(opacity) && !is.na(opacity) && unique(opacity) != 1){
+            transformed <- magick::image_fx(transformed, expression = paste0("u.a * ", opacity), channel = "alpha")
+        }
+        #transformed <- color_image(transformed, colour, opacity)
       }
 
       cache_set_transformed(tkey, transformed, use_cache)

--- a/R/geom_phylopic.R
+++ b/R/geom_phylopic.R
@@ -3,12 +3,15 @@
 ##'
 ##' @title geom_phylopic
 ##' @inheritParams geom_pokemon
+##' @param image_fun a function to process magick-image objects, default is
+##' \code{function(x)magick::image_background(x, color = "none", flatten = FALSE)}.
 ##' @return ggplot2 layer
 ##' @export
 ##' @author Guangchuang Yu
 geom_phylopic <- function(mapping=NULL, data=NULL, inherit.aes=TRUE,
-                       na.rm=FALSE, by="width", ...) {
-    geom_image(mapping, data, inherit.aes=inherit.aes, na.rm=na.rm, ..., .fun = phylopic)
+                       na.rm=FALSE, by="width", 
+                       image_fun = function(x)magick::image_background(x, color = "none", flatten = FALSE), ...) {
+    geom_image(mapping, data, inherit.aes=inherit.aes, na.rm=na.rm, image_fun = image_fun, ..., .fun = phylopic)
 }
 
 ##' download phylopic images

--- a/R/geom_subview.R
+++ b/R/geom_subview.R
@@ -34,7 +34,7 @@ geom_subview <- function(mapping = NULL, data = NULL, width=.1, height=.1, x = N
     }
 
     if (is.null(mapping)) {
-        mapping <- aes_(x = ~x, y = ~y)
+        mapping <- aes(x = x, y = y)
     }
     mapping <- as.list(mapping)
     if (is.null(mapping$x)) {

--- a/R/ggbackground.R
+++ b/R/ggbackground.R
@@ -10,7 +10,7 @@
 ##' @export
 ##' @author guangchuang yu
 ggbackground <- function(gg, background, ...) {
-    ggplot(data.frame(x = 0:1, y = 0:1), aes_(x = ~x, y = ~y)) +
+    ggplot(data.frame(x = 0:1, y = 0:1), aes(x = !!as.symbol("x"), y = !!as.symbol("y"))) +
         geom_image(image = background,size=Inf, ...) +
         geom_subview(subview = gg + theme_transparent(),
                      width=Inf, height=Inf, x=.5, y=.5) +

--- a/man/geom_phylopic.Rd
+++ b/man/geom_phylopic.Rd
@@ -10,6 +10,7 @@ geom_phylopic(
   inherit.aes = TRUE,
   na.rm = FALSE,
   by = "width",
+  image_fun = function(x) magick::image_background(x, color = "none", flatten = FALSE),
   ...
 )
 }
@@ -23,6 +24,9 @@ geom_phylopic(
 \item{na.rm}{whether remove NA values}
 
 \item{by}{one of 'width' or 'height' for specifying size}
+
+\item{image_fun}{a function to process magick-image objects, default is
+\code{function(x)magick::image_background(x, color = "none", flatten = FALSE)}.}
 
 \item{...}{additional parameter}
 }


### PR DESCRIPTION
The `opacity` argument of `magick::image_colorize` does not control the transparency of images. This PR uses the `magcik::image_fx` to control.
